### PR TITLE
Remove verbose flag from tar create.

### DIFF
--- a/build.js
+++ b/build.js
@@ -32,7 +32,7 @@ module.exports = async function build({ filename, push, sequential }, properties
         const steps =
         [
             `printf "${includes}"`,
-            `tar -cv --files-from - `,
+            `tar -c --files-from - `,
             toBuildCommand(image, DockerfilePath)
         ].join(" | ")
 


### PR DESCRIPTION
The current build process with ISX logs every file that will go into the image, due to the `-v` flag when creating the tarball.  Because these lines are dominated by the contents of `node_modules/`, they are not very useful and obscure the more useful parts of the build logs.